### PR TITLE
Add utf-8 support

### DIFF
--- a/examples/main.ç
+++ b/examples/main.ç
@@ -1,3 +1,0 @@
-proc main() {
-    print("Hello, world!\n");
-}

--- a/examples/main.ç
+++ b/examples/main.ç
@@ -1,0 +1,3 @@
+proc main() {
+     print("Hello, world!\n");
+}

--- a/src/cdilla_lexer.c
+++ b/src/cdilla_lexer.c
@@ -165,26 +165,31 @@ Cdilla_Token cdilla_lexer_next(Cdilla_Lexer *lexer) {
     }
 
     if (lexer->content.data[lexer->index] == '"') {
-        size_t count = 1;
+        const char *begin = &lexer->content.data[lexer->index];
+        cdilla_lexer_cut_char(lexer);
+
+        size_t begin_count = lexer->index;
         Cdilla_Token_Kind kind = CDILLA_TOKEN_UNCLOSED_STRING;
-        while (lexer->index + count < lexer->content.count) {
-            char ch = lexer->content.data[lexer->index + count];
+
+        while (lexer->index < lexer->content.count) {
+            char ch = lexer->content.data[lexer->index];
             if (ch == '\n') {
                 break;
             }
-            count += 1;
+            cdilla_lexer_cut_char(lexer);
             if (ch == '"') {
                 kind = CDILLA_TOKEN_STRING;
                 break;
             }
             if (ch == '\\') {
-                if (lexer->index + count >= lexer->content.count) {
+                if (lexer->index >= lexer->content.count) {
                     break;
                 }
-                count += 1;
+                cdilla_lexer_cut_char(lexer);
             }
         }
-        String_View text = cdilla_lexer_cut(lexer, count);
+
+        String_View text = { begin, lexer->index - begin_count };
         return (Cdilla_Token) { text, kind, loc };
     }
 

--- a/src/cdilla_lexer.c
+++ b/src/cdilla_lexer.c
@@ -1,17 +1,25 @@
 #include "./cdilla_lexer.h"
 
-Cdilla_Token_Literal cdilla_token_literals[] = {
-    // Symbols
+Cdilla_Token_Literal cdilla_symbol_literals[] = {
     { .text = SV("("), .kind = CDILLA_TOKEN_OPEN_PAREN },
     { .text = SV(")"), .kind = CDILLA_TOKEN_CLOSE_PAREN },
     { .text = SV("{"), .kind = CDILLA_TOKEN_OPEN_CURLY },
     { .text = SV("}"), .kind = CDILLA_TOKEN_CLOSE_CURLY },
     { .text = SV(";"), .kind = CDILLA_TOKEN_SEMI_COLON },
+};
 
-    // Keywords
+Cdilla_Token_Literal cdilla_keyword_literals[] = {
     { .text = SV("proc"), .kind = CDILLA_TOKEN_PROC },
     { .text = SV("print"), .kind = CDILLA_TOKEN_PRINT },
 };
+
+int cdilla_is_ident_body(int ch) {
+    return isalpha(ch);
+}
+
+int cdilla_is_ident_head(int ch) {
+    return isalnum(ch);
+}
 
 const char *cdilla_token_kind_cstr_impl(Cdilla_Token_Kind kind, const char *file, int line) {
     switch (kind) {
@@ -35,7 +43,32 @@ const char *cdilla_token_kind_cstr_impl(Cdilla_Token_Kind kind, const char *file
     exit(1);
 }
 
+size_t utf8_char_size(char ch) {
+    if ((ch & (1 << 7)) == 0) return 1;
+    if ((ch & (1 << 5)) == 0) return 2;
+    if ((ch & (1 << 4)) == 0) return 3;
+    if ((ch & (1 << 3)) == 0) return 4;
+    assert(0 && "unreachable");
+}
+
+size_t utf8_sv_char_count(String_View sv) {
+    size_t actual_count = 0;
+
+    size_t i = 0;
+    while (i < sv.count) {
+        size_t char_size = utf8_char_size(sv.data[i]);
+        i += char_size;
+        actual_count += 1;
+    }
+
+    return actual_count;
+}
+
 Cdilla_Lexer cdilla_lexer_new(String_View content, const char *source_filepath) {
+    String_View test = SV("ç");
+    printf("String view size: %zu\n", test.count);
+    printf("Actual size: %zu\n", utf8_sv_char_count(test));
+
     Cdilla_Lexer lexer = {0};
     lexer.filepath = source_filepath;
     lexer.content = content;
@@ -43,34 +76,46 @@ Cdilla_Lexer cdilla_lexer_new(String_View content, const char *source_filepath) 
     return lexer;
 }
 
-String_View cdilla_lexer_cut_impl(Cdilla_Lexer *lexer, size_t count, const char *file, int line) {
-    if (lexer->index + count > lexer->content.count) {
+String_View cdilla_lexer_cut_char_impl(Cdilla_Lexer *lexer, const char *file, int line) {
+    if (lexer->index >= lexer->content.count) {
         fprintf(stderr, "%s:%d: Error: trying to cut out of lexer bounds", file, line);
         exit(1);
     }
 
-    String_View head = {
-        .data = &lexer->content.data[lexer->index],
-        .count = count,
-    };
+    const char *ch = &lexer->content.data[lexer->index];
+    size_t char_size = utf8_char_size(*ch);
+    lexer->index += char_size;
+
+    if (*ch == '\n') {
+        lexer->line += 1;
+        lexer->bol = lexer->index;
+    }
+
+    return (String_View) { ch, char_size };
+}
+
+String_View cdilla_lexer_cut_impl(Cdilla_Lexer *lexer, size_t count, const char *file, int line) {
+    const char *begin = &lexer->content.data[lexer->index];
+    size_t actual_count = 0;
 
     for (size_t i = 0; i < count; ++i) {
-        char ch = lexer->content.data[lexer->index];
-        lexer->index += 1;
-        if (ch == '\n') {
-            lexer->line += 1;
-            lexer->bol = lexer->index;
-        }
+        String_View ch = cdilla_lexer_cut_char_impl(lexer, file, line);
+        actual_count += ch.count;
     }
-    return head;
+
+    return (String_View) { begin, actual_count };
 }
 
 String_View cdilla_lexer_cut_while(Cdilla_Lexer *lexer, int (*predicate)(int)) {
-    size_t count = 0;
-    while (lexer->index < lexer->content.count && predicate(lexer->content.data[lexer->index + count])) {
-        count += 1;
+    const char *begin = &lexer->content.data[lexer->index];
+    size_t actual_count = 0;
+
+    while (lexer->index < lexer->content.count && predicate(lexer->content.data[lexer->index])) {
+        String_View ch = cdilla_lexer_cut_char(lexer);
+        actual_count += ch.count;
     }
-    return cdilla_lexer_cut(lexer, count);
+
+    return (String_View) { begin, actual_count };
 }
 
 bool cdilla_lexer_starts_with(Cdilla_Lexer *lexer, String_View prefix) {
@@ -84,47 +129,43 @@ Cdilla_Token cdilla_lexer_next(Cdilla_Lexer *lexer) {
     // TODO: lex comments
     cdilla_lexer_cut_while(lexer, isspace);
 
-    if (lexer->index >= lexer->content.count) {
-        return (Cdilla_Token) {
-            .kind = CDILLA_TOKEN_END,
-            .text = SV("<end>"),
-        };
-    }
-
     Cdilla_Loc loc = {
         .filepath = lexer->filepath,
         .row = lexer->line,
         .column = lexer->index - lexer->bol + 1,
     };
 
-    for (size_t i = 0; i < array_len(cdilla_token_literals); ++i) {
-        Cdilla_Token_Literal *literal = &cdilla_token_literals[i];
+    if (lexer->index >= lexer->content.count) {
+        return (Cdilla_Token) {
+            .text = SV("<end>"),
+            .kind = CDILLA_TOKEN_END,
+            .loc = loc,
+        };
+    }
+
+    for (size_t i = 0; i < array_len(cdilla_symbol_literals); ++i) {
+        Cdilla_Token_Literal *literal = &cdilla_symbol_literals[i];
         if (cdilla_lexer_starts_with(lexer, literal->text)) {
             String_View text = cdilla_lexer_cut(lexer, literal->text.count);
-            return (Cdilla_Token) {
-                .kind = literal->kind,
-                .text = text,
-                .loc = loc,
-            };
+            return (Cdilla_Token) { text, literal->kind, loc };
         }
     }
 
-    if (isalpha(lexer->content.data[lexer->index])) {
-        String_View text = cdilla_lexer_cut_while(lexer, isalnum);
-        return (Cdilla_Token) {
-            .text = text,
-            .kind = CDILLA_TOKEN_IDENTIFIER,
-            .loc = loc,
-        };
+    if (cdilla_is_ident_head(lexer->content.data[lexer->index])) {
+        String_View text = cdilla_lexer_cut_while(lexer, cdilla_is_ident_body);
+        Cdilla_Token_Kind kind = CDILLA_TOKEN_IDENTIFIER;
+        for (size_t i = 0; i < array_len(cdilla_keyword_literals); ++i) {
+            Cdilla_Token_Literal *literal = &cdilla_keyword_literals[i];
+            if (sv_eq(text, literal->text)) {
+                kind = literal->kind;
+            }
+        }
+        return (Cdilla_Token) { text, kind, loc };
     }
 
     if (isdigit(lexer->content.data[lexer->index])) {
         String_View text = cdilla_lexer_cut_while(lexer, isdigit);
-        return (Cdilla_Token) {
-            .text = text,
-            .kind = CDILLA_TOKEN_INTEGER,
-            .loc = loc,
-        };
+        return (Cdilla_Token) { text, CDILLA_TOKEN_INTEGER, loc };
     }
 
     if (lexer->content.data[lexer->index] == '"') {
@@ -151,10 +192,6 @@ Cdilla_Token cdilla_lexer_next(Cdilla_Lexer *lexer) {
         return (Cdilla_Token) { text, kind, loc };
     }
 
-    String_View text = cdilla_lexer_cut(lexer, 1);
-    return (Cdilla_Token) {
-        .text = text,
-        .kind = CDILLA_TOKEN_UNKNOWN,
-        .loc = loc,
-    };
+    String_View text = cdilla_lexer_cut_char(lexer);
+    return (Cdilla_Token) { text, CDILLA_TOKEN_UNKNOWN, loc };
 }

--- a/src/cdilla_lexer.c
+++ b/src/cdilla_lexer.c
@@ -65,10 +65,6 @@ size_t utf8_sv_char_count(String_View sv) {
 }
 
 Cdilla_Lexer cdilla_lexer_new(String_View content, const char *source_filepath) {
-    String_View test = SV("ç");
-    printf("String view size: %zu\n", test.count);
-    printf("Actual size: %zu\n", utf8_sv_char_count(test));
-
     Cdilla_Lexer lexer = {0};
     lexer.filepath = source_filepath;
     lexer.content = content;

--- a/src/cdilla_lexer.h
+++ b/src/cdilla_lexer.h
@@ -56,6 +56,9 @@ typedef struct {
     Cdilla_Token_Kind kind;
 } Cdilla_Token_Literal;
 
+#define cdilla_lexer_cut_char(lexer) \
+    cdilla_lexer_cut_char_impl((lexer), __FILE__, __LINE__)
+
 #define cdilla_lexer_cut(lexer, count) \
     cdilla_lexer_cut_impl((lexer), (count), __FILE__, __LINE__)
 
@@ -65,6 +68,8 @@ typedef struct {
 const char *cdilla_token_kind_cstr_impl(Cdilla_Token_Kind kind, const char *file, int line);
 
 Cdilla_Lexer cdilla_lexer_new(String_View content, const char *source_filepath);
+// NOTE(nic): this respects utf8 strings, that's why it returns String_View
+String_View cdilla_lexer_cut_char_impl(Cdilla_Lexer *lexer, const char *file, int line);
 String_View cdilla_lexer_cut_impl(Cdilla_Lexer *lexer, size_t count, const char *file, int line);
 // NOTE(nic): isdigit, isalnum and isspace are int (*)(int), don't ask me why
 String_View cdilla_lexer_cut_while(Cdilla_Lexer *lexer, int (*predicate)(int));

--- a/src/main.c
+++ b/src/main.c
@@ -256,6 +256,7 @@ Cdilla_Ast cdilla_parse(Cdilla_Lexer *lexer) {
             stop = true;
         } break;
         default: {
+            printf(SV_FMT"\n", SV_ARG(token.text));
             fprintf(
                 stderr,
                 LOC_FMT": Error: expected `%s` or `%s`, but got `%s`\n",

--- a/src/main.c
+++ b/src/main.c
@@ -148,10 +148,9 @@ Cdilla_Expression_Id cdilla_parse_expression(Cdilla_Ast *ast, Cdilla_Lexer *lexe
         expression.as.int_32 = int_32;
     } break;
     case CDILLA_TOKEN_STRING: {
-        char string[token.text.count + 1];
-        size_t len = 0;
-
+        size_t begin = ast->strings.count;
         size_t i = 1;
+
         while (i < token.text.count - 1) {
             char ch = token.text.data[i++];
             if (ch == '\\') {
@@ -159,7 +158,7 @@ Cdilla_Expression_Id cdilla_parse_expression(Cdilla_Ast *ast, Cdilla_Lexer *lexe
                 bool exists = false;
                 for (size_t j = 0; j < array_len(escape_chars); ++j) {
                     if (escape_chars[j].ch == next_ch) {
-                        string[len++] = escape_chars[j].escape_ch;
+                        da_append(&ast->strings, escape_chars[j].escape_ch);
                         exists = true;
                         break;
                     }
@@ -172,13 +171,10 @@ Cdilla_Expression_Id cdilla_parse_expression(Cdilla_Ast *ast, Cdilla_Lexer *lexe
                     exit(1);
                 }
             } else {
-                string[len++] = ch;
+                da_append(&ast->strings, ch);
             }
         }
-        string[len++] = '\0';
-
-        size_t begin = ast->strings.count;
-        sb_add_sized_str(&ast->strings, string, len);
+        da_append(&ast->strings, '\0');
 
         expression.kind = CDILLA_EXPRESSION_STRING;
         expression.as.string_index = begin;

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,6 +19,17 @@
 #define SV_FMT "%.*s"
 #define SV_ARG(sv) (int) (sv).count, (sv).data
 
+#define BYTE_FMT "%c%c%c%c%c%c%c%c"
+#define BYTE_ARG(byte)           \
+    ((byte) & 0x80 ? '1' : '0'), \
+    ((byte) & 0x40 ? '1' : '0'), \
+    ((byte) & 0x20 ? '1' : '0'), \
+    ((byte) & 0x10 ? '1' : '0'), \
+    ((byte) & 0x08 ? '1' : '0'), \
+    ((byte) & 0x04 ? '1' : '0'), \
+    ((byte) & 0x02 ? '1' : '0'), \
+    ((byte) & 0x01 ? '1' : '0')
+
 typedef int8_t i8;
 typedef int16_t i16;
 typedef int32_t i32;


### PR DESCRIPTION
Sadly we can't have identifier being utf-8 characters, because I haven't figured out how to get the category of each character, but the lexer does consider the length of multi-byte characters, so we are halfway there.